### PR TITLE
feat: force uppercase in search input and fix header visibility

### DIFF
--- a/pathology/viewer/src/components/search-page/search-page.component.html
+++ b/pathology/viewer/src/components/search-page/search-page.component.html
@@ -15,7 +15,7 @@
 -->
 
 <div class="search-page">
-    <div class="header" *ngIf="!searchText">
+    <div class="header" *ngIf="!searchText.value">
         <div class="header-logo" [routerLink]="['/']">
             <img src="../../favicon.ico" alt="Logo" />
             <span> Pathology Image Library </span>

--- a/pathology/viewer/src/components/search-page/search-page.component.ts
+++ b/pathology/viewer/src/components/search-page/search-page.component.ts
@@ -115,6 +115,16 @@ export class SearchPageComponent implements OnInit, OnChanges, OnDestroy {
     if (this.searchOnLoad && this.searchTextDefault) {
       this.search();
     }
+    if (this.forceUpperCase) {
+      this.searchText.valueChanges
+        .pipe(takeUntil(this.destroyed$))
+        .subscribe(value => {
+          const upper = value.toUpperCase();
+          if (value !== upper) {
+            this.searchText.setValue(upper, { emitEvent: false });
+          }
+        });
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
- Search input now automatically converts user input to uppercase when SEARCH_UPPERCASE_ONLY is enabled.
- Header section displays only when the search field is empty.
- Updated template bindings to use searchText.value for correct UI state.

The search input field now automatically converts user input to uppercase as the user types, when SEARCH_UPPERCASE_ONLY is enabled in the environment. This is handled by subscribing to the FormControl value changes and updating the value to uppercase if needed.

The header section in the search page is now conditionally displayed based on the value of the search input field. The header will only show when the search field is empty, improving the user experience and visual clarity.

The [allowSelecting], [showEmptyMessage], and [searchText] bindings in the template now use searchText.value to correctly reflect the current state of the search input.

These changes improve input consistency, UI responsiveness, and ensure the header visibility logic matches the intended design.